### PR TITLE
DefaultInstantiator is not capable of instantiating any controller

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "codeinc/router",
-  "version": "1.3.9",
+  "version": "1.3.10",
   "description": "Code Inc. PSR7 & PSR15 router library",
   "homepage": "https://github.com/CodeIncHQ/Router",
   "type": "library",

--- a/src/Exceptions/DefaultInstantiatorException.php
+++ b/src/Exceptions/DefaultInstantiatorException.php
@@ -1,0 +1,35 @@
+<?php
+//
+// +---------------------------------------------------------------------+
+// | CODE INC. SOURCE CODE                                               |
+// +---------------------------------------------------------------------+
+// | Copyright (c) 2017 - Code Inc. SAS - All Rights Reserved.           |
+// | Visit https://www.codeinc.fr for more information about licensing.  |
+// +---------------------------------------------------------------------+
+// | NOTICE:  All information contained herein is, and remains the       |
+// | property of Code Inc. SAS. The intellectual and technical concepts  |
+// | contained herein are proprietary to Code Inc. SAS are protected by  |
+// | trade secret or copyright law. Dissemination of this information or |
+// | reproduction of this material  is strictly forbidden unless prior   |
+// | written permission is obtained from Code Inc. SAS.                  |
+// +---------------------------------------------------------------------+
+//
+// Author:   Joan Fabrégat <joan@codeinc.fr>
+// Date:     22/03/2018
+// Time:     10:28
+// Project:  Router
+//
+declare(strict_types = 1);
+namespace CodeInc\Router\Exceptions;
+
+
+/**
+ * Class DefaultInstantiatorException
+ *
+ * @package CodeInc\Router\Exceptions
+ * @author Joan Fabrégat <joan@codeinc.fr>
+ */
+class DefaultInstantiatorException extends RouterException
+{
+
+}

--- a/src/Instantiators/DefaultInstantiatorControllerInterface.php
+++ b/src/Instantiators/DefaultInstantiatorControllerInterface.php
@@ -1,0 +1,42 @@
+<?php
+//
+// +---------------------------------------------------------------------+
+// | CODE INC. SOURCE CODE                                               |
+// +---------------------------------------------------------------------+
+// | Copyright (c) 2017 - Code Inc. SAS - All Rights Reserved.           |
+// | Visit https://www.codeinc.fr for more information about licensing.  |
+// +---------------------------------------------------------------------+
+// | NOTICE:  All information contained herein is, and remains the       |
+// | property of Code Inc. SAS. The intellectual and technical concepts  |
+// | contained herein are proprietary to Code Inc. SAS are protected by  |
+// | trade secret or copyright law. Dissemination of this information or |
+// | reproduction of this material  is strictly forbidden unless prior   |
+// | written permission is obtained from Code Inc. SAS.                  |
+// +---------------------------------------------------------------------+
+//
+// Author:   Joan Fabrégat <joan@codeinc.fr>
+// Date:     22/03/2018
+// Time:     10:18
+// Project:  Router
+//
+declare(strict_types = 1);
+namespace CodeInc\Router\Instantiators;
+use CodeInc\Router\ControllerInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+
+/**
+ * Interface DefaultInstantiatorControllerInterface
+ *
+ * @package CodeInc\Router\Instantiators
+ * @author Joan Fabrégat <joan@codeinc.fr>
+ */
+interface DefaultInstantiatorControllerInterface extends ControllerInterface
+{
+    /**
+     * DefaultInstantiatorControllerInterface constructor.
+     *
+     * @param ServerRequestInterface $request
+     */
+    public function __construct(ServerRequestInterface $request);
+}


### PR DESCRIPTION
`DefaultInstantiator` is not capable of instantiating any controller as long as the `ServerRequestInterface` is the only required parameter (i.e. without a default value) or as long as the constructor does not have any required parameter. `DefaultInstantiator` uses [PHP reflection API](http://php.net/manual/fr/book.reflection.php) to read `__construct()` method's parameters.