### PR TITLE
v3.3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "codeinc/router",
-  "version": "3.2.6",
+  "version": "3.3.0",
   "description": "Code Inc. PSR7 & PSR15 router library",
   "homepage": "https://github.com/CodeIncHQ/Router",
   "type": "library",

--- a/src/Exceptions/NotARoutableHandlerException.php
+++ b/src/Exceptions/NotARoutableHandlerException.php
@@ -1,0 +1,66 @@
+<?php
+//
+// +---------------------------------------------------------------------+
+// | CODE INC. SOURCE CODE                                               |
+// +---------------------------------------------------------------------+
+// | Copyright (c) 2018 - Code Inc. SAS - All Rights Reserved.           |
+// | Visit https://www.codeinc.fr for more information about licensing.  |
+// +---------------------------------------------------------------------+
+// | NOTICE:  All information contained herein is, and remains the       |
+// | property of Code Inc. SAS. The intellectual and technical concepts  |
+// | contained herein are proprietary to Code Inc. SAS are protected by  |
+// | trade secret or copyright law. Dissemination of this information or |
+// | reproduction of this material is strictly forbidden unless prior    |
+// | written permission is obtained from Code Inc. SAS.                  |
+// +---------------------------------------------------------------------+
+//
+// Author:   Joan Fabrégat <joan@codeinc.fr>
+// Date:     12/10/2018
+// Project:  Router
+//
+declare(strict_types=1);
+namespace CodeInc\Router\Exceptions;
+use CodeInc\Router\Resolvers\MultiRoutableRequestHandlerInterface;
+use CodeInc\Router\Resolvers\RoutableRequestHandlerInterface;
+use Throwable;
+
+
+/**
+ * Class NotARoutableHandlerException
+ *
+ * @package CodeInc\Router\Exceptions
+ * @author Joan Fabrégat <joan@codeinc.fr>
+ */
+class NotARoutableHandlerException extends \LogicException implements RouterException
+{
+    /**
+     * @var string
+     */
+    private $class;
+
+    /**
+     * NotARoutableHandlerException constructor.
+     *
+     * @param string $class
+     * @param int $code
+     * @param Throwable|null $previous
+     */
+    public function __construct(string $class, int $code = 0, Throwable $previous = null)
+    {
+        $this->class = $class;
+        parent::__construct(
+            sprintf("The class '%s' is not a routable handler. All routable handler must implement '%s' or '%s'.",
+                $class, RoutableRequestHandlerInterface::class, MultiRoutableRequestHandlerInterface::class),
+            $code,
+            $previous
+        );
+    }
+
+    /**
+     * @return string
+     */
+    public function getClass():string
+    {
+        return $this->class;
+    }
+}

--- a/src/Resolvers/MultiRoutableRequestHandlerInterface.php
+++ b/src/Resolvers/MultiRoutableRequestHandlerInterface.php
@@ -1,0 +1,40 @@
+<?php
+//
+// +---------------------------------------------------------------------+
+// | CODE INC. SOURCE CODE                                               |
+// +---------------------------------------------------------------------+
+// | Copyright (c) 2018 - Code Inc. SAS - All Rights Reserved.           |
+// | Visit https://www.codeinc.fr for more information about licensing.  |
+// +---------------------------------------------------------------------+
+// | NOTICE:  All information contained herein is, and remains the       |
+// | property of Code Inc. SAS. The intellectual and technical concepts  |
+// | contained herein are proprietary to Code Inc. SAS are protected by  |
+// | trade secret or copyright law. Dissemination of this information or |
+// | reproduction of this material is strictly forbidden unless prior    |
+// | written permission is obtained from Code Inc. SAS.                  |
+// +---------------------------------------------------------------------+
+//
+// Author:   Joan Fabrégat <joan@codeinc.fr>
+// Date:     12/10/2018
+// Project:  Router
+//
+declare(strict_types=1);
+namespace CodeInc\Router\Resolvers;
+use Psr\Http\Server\RequestHandlerInterface;
+
+
+/**
+ * Interface MultiRoutableRequestHandlerInterface
+ *
+ * @package CodeInc\Router\Resolvers
+ * @author Joan Fabrégat <joan@codeinc.fr>
+ */
+interface MultiRoutableRequestHandlerInterface extends RequestHandlerInterface
+{
+    /**
+     * Returns the routes for the current request handler.
+     *
+     * @return string[]|iterable
+     */
+    public static function getRoutes():iterable;
+}

--- a/src/Resolvers/RoutableHandlerResolver.php
+++ b/src/Resolvers/RoutableHandlerResolver.php
@@ -1,0 +1,57 @@
+<?php
+//
+// +---------------------------------------------------------------------+
+// | CODE INC. SOURCE CODE                                               |
+// +---------------------------------------------------------------------+
+// | Copyright (c) 2018 - Code Inc. SAS - All Rights Reserved.           |
+// | Visit https://www.codeinc.fr for more information about licensing.  |
+// +---------------------------------------------------------------------+
+// | NOTICE:  All information contained herein is, and remains the       |
+// | property of Code Inc. SAS. The intellectual and technical concepts  |
+// | contained herein are proprietary to Code Inc. SAS are protected by  |
+// | trade secret or copyright law. Dissemination of this information or |
+// | reproduction of this material is strictly forbidden unless prior    |
+// | written permission is obtained from Code Inc. SAS.                  |
+// +---------------------------------------------------------------------+
+//
+// Author:   Joan Fabrégat <joan@codeinc.fr>
+// Date:     12/10/2018
+// Project:  Router
+//
+declare(strict_types=1);
+namespace CodeInc\Router\Resolvers;
+use CodeInc\Router\Exceptions\NotARoutableHandlerException;
+
+
+/**
+ * Class RoutableHandlerResolver
+ *
+ * @package CodeInc\Router\Resolvers
+ * @author Joan Fabrégat <joan@codeinc.fr>
+ */
+class RoutableHandlerResolver extends StaticHandlerResolver
+{
+    /**
+     * Adds a routable handler to the resolver.
+     *
+     * @param string $handlerClass
+     */
+    public function addHandler(string $handlerClass):void
+    {
+        if (is_subclass_of($handlerClass, RoutableRequestHandlerInterface::class)) {
+            /** @var RoutableRequestHandlerInterface $handlerClass */
+            /** @noinspection PhpStrictTypeCheckingInspection */
+            $this->addRoute($handlerClass::getRoute(), $handlerClass);
+        }
+        elseif (is_subclass_of($handlerClass, MultiRoutableRequestHandlerInterface::class)) {
+            /** @var MultiRoutableRequestHandlerInterface $handlerClass */
+            foreach ($handlerClass::getRoutes() as $route) {
+                /** @noinspection PhpStrictTypeCheckingInspection */
+                $this->addRoute($route, $handlerClass);
+            }
+        }
+        else {
+            throw new NotARoutableHandlerException($handlerClass);
+        }
+    }
+}

--- a/src/Resolvers/RoutableRequestHandlerInterface.php
+++ b/src/Resolvers/RoutableRequestHandlerInterface.php
@@ -1,0 +1,40 @@
+<?php
+//
+// +---------------------------------------------------------------------+
+// | CODE INC. SOURCE CODE                                               |
+// +---------------------------------------------------------------------+
+// | Copyright (c) 2018 - Code Inc. SAS - All Rights Reserved.           |
+// | Visit https://www.codeinc.fr for more information about licensing.  |
+// +---------------------------------------------------------------------+
+// | NOTICE:  All information contained herein is, and remains the       |
+// | property of Code Inc. SAS. The intellectual and technical concepts  |
+// | contained herein are proprietary to Code Inc. SAS are protected by  |
+// | trade secret or copyright law. Dissemination of this information or |
+// | reproduction of this material is strictly forbidden unless prior    |
+// | written permission is obtained from Code Inc. SAS.                  |
+// +---------------------------------------------------------------------+
+//
+// Author:   Joan Fabrégat <joan@codeinc.fr>
+// Date:     12/10/2018
+// Project:  Router
+//
+declare(strict_types=1);
+namespace CodeInc\Router\Resolvers;
+use Psr\Http\Server\RequestHandlerInterface;
+
+
+/**
+ * Class RoutableRequestHandlerInterface
+ *
+ * @package CodeInc\Router\Resolvers
+ * @author Joan Fabrégat <joan@codeinc.fr>
+ */
+interface RoutableRequestHandlerInterface extends RequestHandlerInterface
+{
+    /**
+     * Returns the route for the current request handler.
+     *
+     * @return string
+     */
+    public static function getRoute():string;
+}

--- a/src/Router.php
+++ b/src/Router.php
@@ -51,7 +51,7 @@ class Router implements MiddlewareInterface
     /**
      * Router constructor.
      *
-     * @param HandlerResolverInterface|null $resolver
+     * @param HandlerResolverInterface $resolver
      * @param HandlerInstantiatorInterface $instantiator
      */
     public function __construct(HandlerResolverInterface $resolver, HandlerInstantiatorInterface $instantiator)


### PR DESCRIPTION
* Adds the support for routable handlers (through `RoutableHandlerResolver`, `RoutableRequestHandlerInterface` and `MultiRoutableRequestHandlerInterface`)
* Fixes a typo in the phpDoc of `Route:: __construct()`
